### PR TITLE
class.xmlimporter.php - switch is_countable() to array()

### DIFF
--- a/lib/class.xmlimporter.php
+++ b/lib/class.xmlimporter.php
@@ -264,10 +264,10 @@
 					$field = FieldManager::fetch($field_id);
 
 					if(is_array($value)) {
-						if(count(is_countable($value)) === 1) {
+						if(count(array($value)) === 1) {
 							$value = current($value);
 						}
-						if(count(is_countable($value)) === 0) {
+						if(count(array($value)) === 0) {
 							$value = '';
 						}
 					}


### PR DESCRIPTION
On PHP 7.2 `is_countable` creates an undefined function. `is_countable` is not available until PHP 7.3, <https://www.php.net/manual/en/function.is-countable.php>. 

In PHP 7.3, I get this error... "count(): Parameter must be an array or an object that implements Countable".

BUT, I found this... instead of `is_countable($value)`, **it works with `array($value)`** which I got from this Stack Overflow post, <https://stackoverflow.com/a/59818642>.